### PR TITLE
Feature/cors

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -1,4 +1,5 @@
 const Koa = require("koa");
+const cors = require("@koa/cors");
 const config = require("config");
 const logger = require("logger");
 const koaLogger = require("koa-logger");
@@ -18,6 +19,7 @@ const loggedInUserService = require("./services/LoggedInUserService");
 const app = new Koa();
 validate(app);
 
+app.use(cors());
 app.use(convert(koaBody));
 
 app.use(async (ctx, next) => {

--- a/app/test/e2e/health-check.spec.js
+++ b/app/test/e2e/health-check.spec.js
@@ -6,7 +6,7 @@ chai.should();
 
 let requester;
 
-describe("GET /api/v1/fw_alerts/healthcheck", function () {
+describe("GET /v1/fw_alerts/healthcheck", function () {
   // eslint-disable-next-line mocha/no-hooks-for-single-case
   before(async function () {
     if (process.env.NODE_ENV !== "test") {
@@ -19,7 +19,7 @@ describe("GET /api/v1/fw_alerts/healthcheck", function () {
   });
 
   it("Checking the application's health should return a 200", async function () {
-    const response = await requester.get("/api/v1/fw_alerts/healthcheck");
+    const response = await requester.get("/v1/fw_alerts/healthcheck");
 
     response.status.should.equal(200);
     response.body.should.be.an("object").and.have.property("uptime");

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "prettier": "^2.5.1"
   },
   "dependencies": {
+    "@koa/cors": "^3.1.0",
     "axios": "^0.21.1",
     "bunyan": "^1.8.5",
     "config": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,7 +228,7 @@
 
 "@koa/cors@^3.1.0":
   version "3.1.0"
-  resolved "https://registry.npmjs.org/@koa/cors/-/cors-3.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-3.1.0.tgz#618bb073438cfdbd3ebd0e648a76e33b84f3a3b2"
   integrity sha512-7ulRC1da/rBa6kj6P4g2aJfnET3z8Uf3SWu60cjbtxTA5g8lxRdX/Bd2P92EagGwwAhANeNw8T8if99rJliR6Q==
   dependencies:
     vary "^1.1.2"


### PR DESCRIPTION
cors added to the app.

by default [cors package](https://www.npmjs.com/package/@koa/cors) sets the response header `Access-Control-Allow-Origin` as the request `Origin` header.

So:
mydomain.com ---------------`Origin: mydomain.com`--------------> someDomain.com
mydomain.com <---`Access-Control-Allow-Origin: mydomain.com`--- someDomain.com

Basically the same as the wildcard *

Also updated the healthcheck endpoint in the tests