### PR TITLE
High: staging urls updated for the dev environment (tiny)

### DIFF
--- a/terraform/vars/terraform-dev.tfvars
+++ b/terraform/vars/terraform-dev.tfvars
@@ -8,7 +8,7 @@ container_port = 4200
 node_env = "dev"
 suppress_no_config_warning = "true"
 control_tower_url = "https://staging-api.resourcewatch.org"
-glad_alerts_api_url = "https://gfw-staging.globalforestwatch.org"
+glad_alerts_api_url = "https://staging-api.resourcewatch.org"
 
 healthcheck_path = "/v1/fw_alerts/healthcheck"
 healthcheck_sns_emails = ["server@3sidedcube.com"]


### PR DESCRIPTION
`https://gfw-staging.globalforestwatch.org` has gone down, needs to be replaced with `https://staging-api.resourcewatch.org`